### PR TITLE
Use @svg

### DIFF
--- a/resources/views/components/create-menu.blade.php
+++ b/resources/views/components/create-menu.blade.php
@@ -10,7 +10,7 @@
             'dark:bg-gray-900' => config('filament.dark_mode'),
         ])
     >
-        <x-heroicon-o-plus class="w-4 h-4" />
+        @svg('heroicon-o-plus', 'w-4 h-4')
     </button>
 
     <div


### PR DESCRIPTION
Please make this package support users that choose to disable blade components in 
`config/blade-icons.components.disabled`.

It is a non-breaking change.

(Filament v3 will also switch to using the `@svg()` directive.)