### PR TITLE
feat: add hidden() to plugin config

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,20 @@ public function panel(Panel $panel): Panel
         ])
 }
 ```
+
+### Hiding Quick Create
+
+By default, Quick Create is visible if there are registered resources. If you would like to hide it you may use the `hidden()` modifier to do so.
+
+```php
+use Awcodes\FilamentQuickCreate\QuickCreatePlugin;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        ->plugins([
+            QuickCreatePlugin::make()
+                ->hidden(fn() => Filament::getTenant()->requiresOnboarding()),
+        ])
+}
+```

--- a/resources/views/components/create-menu.blade.php
+++ b/resources/views/components/create-menu.blade.php
@@ -1,5 +1,5 @@
 <div class="quick-create-component">
-@if ($resources)
+@if ($resources && $this->shouldBeHidden() === false)
     <x-filament::dropdown placement="bottom-end">
         <x-slot name="trigger">
             <button

--- a/src/Components/QuickCreateMenu.php
+++ b/src/Components/QuickCreateMenu.php
@@ -75,6 +75,11 @@ class QuickCreateMenu extends Component implements HasForms, HasActions
             ->toArray();
     }
 
+    public function shouldBeHidden(): bool
+    {
+        return QuickCreatePlugin::get()->shouldBeHidden();
+    }
+
     public function render(): View
     {
         return view('filament-quick-create::components.create-menu');

--- a/src/QuickCreatePlugin.php
+++ b/src/QuickCreatePlugin.php
@@ -23,15 +23,17 @@ class QuickCreatePlugin implements Plugin
 
     protected bool $sort = true;
 
-    protected bool | Closure | null $shouldUseSlideOver = null;
+    protected bool|Closure|null $shouldUseSlideOver = null;
 
-    protected string | Closure $sortBy = 'label';
+    protected string|Closure $sortBy = 'label';
+
+    protected bool|Closure $hidden = false;
 
     public function boot(Panel $panel): void
     {
         Livewire::component('quick-create-menu', Components\QuickCreateMenu::class);
 
-        $this->getResourcesUsing(fn () => $panel->getResources());
+        $this->getResourcesUsing(fn() => $panel->getResources());
     }
 
     public function excludes(array $resources): static
@@ -76,12 +78,12 @@ class QuickCreatePlugin implements Plugin
 
         $list = collect($resources)
             ->filter(function ($item) {
-                return ! in_array($item, $this->getExcludes());
+                return !in_array($item, $this->getExcludes());
             })
             ->map(function ($resourceName): ?array {
                 $resource = app($resourceName);
 
-                if (Filament::hasTenancy() && ! Filament::getTenant()) {
+                if (Filament::hasTenancy() && !Filament::getTenant()) {
                     return null;
                 }
 
@@ -94,7 +96,7 @@ class QuickCreatePlugin implements Plugin
                         'model' => $resource->getModel(),
                         'icon' => $resource->getNavigationIcon(),
                         'action_name' => $actionName,
-                        'action' => ! $resource->hasPage('create') ? 'mountAction(\'' . $actionName . '\')' : null,
+                        'action' => !$resource->hasPage('create') ? 'mountAction(\'' . $actionName . '\')' : null,
                         'url' => $resource->hasPage('create') ? $resource::getUrl('create') : null,
                         'navigation' => $resource->getNavigationSort(),
                     ];
@@ -102,7 +104,7 @@ class QuickCreatePlugin implements Plugin
 
                 return null;
             })
-            ->when($this->isSortable(), fn ($collection) => $collection->sortBy($this->sortBy))
+            ->when($this->isSortable(), fn($collection) => $collection->sortBy($this->sortBy))
             ->values()
             ->toArray();
 
@@ -131,7 +133,7 @@ class QuickCreatePlugin implements Plugin
         $panel
             ->renderHook(
                 name: 'panels::user-menu.before',
-                hook: fn (): string => Blade::render('@livewire(\'quick-create-menu\')')
+                hook: fn(): string => Blade::render('@livewire(\'quick-create-menu\')')
             );
     }
 
@@ -147,21 +149,33 @@ class QuickCreatePlugin implements Plugin
         return $this;
     }
 
-    public function sort(bool | Closure $condition = true): static
+    public function sort(bool|Closure $condition = true): static
     {
         $this->sort = $condition;
 
         return $this;
     }
 
-    public function sortBy(string | Closure $sortBy = 'label'): static
+    public function sortBy(string|Closure $sortBy = 'label'): static
     {
-        if (! in_array($sortBy, ['label', 'navigation'])) {
+        if (!in_array($sortBy, ['label', 'navigation'])) {
             $sortBy = 'label';
         }
 
         $this->sortBy = $sortBy;
 
         return $this;
+    }
+
+    public function hidden(bool|Closure $hidden = true): static
+    {
+        $this->hidden = $hidden;
+
+        return $this;
+    }
+
+    public function shouldBeHidden(): bool
+    {
+        return $this->evaluate($this->hidden) ?? false;
     }
 }


### PR DESCRIPTION
I am using this with a simple page for onboarding, and it's showing the button during the onboarding workflow, with no easy way to hide it without removing all the resources.