### PR TITLE
[Possible Bug]Update QuickCreateMenu.php

### DIFF
--- a/src/Components/QuickCreateMenu.php
+++ b/src/Components/QuickCreateMenu.php
@@ -66,6 +66,7 @@ class QuickCreateMenu extends Component implements HasForms, HasActions
             return CreateAction::make($resource['action_name'])
                 ->authorize($r::canCreate())
                 ->model($resource['model'])
+                ->modelLabel($r->getModelLabel())
                 ->slideOver(fn (): bool => QuickCreatePlugin::get()->shouldUseSlideOver())
                 ->form(function ($arguments, $form) use ($r) {
                     return $r->form($form->operation('create')->columns());


### PR DESCRIPTION
Create action needs a header. 
Cause of null set over, it causes "model name"(ie. user instead of User) displays over modal and slideovers.