### PR TITLE
Render the plugin in a custom render hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,3 +168,21 @@ public function panel(Panel $panel): Panel
         ])
 }
 ```
+
+### Render Plugin on a Custom Panel Hook
+
+By default, Quick Create plugin renders using `'panels::user-menu.before'` Filament Panel Render Hook. If you would like to customize this to render at a different render hook, you may use the `renderUsingHook(string $panelHook)` modifier to do so. You may read about the available Render Hooks in Filament PHP [here](https://filamentphp.com/docs/3.x/support/render-hooks#available-render-hooks)
+
+```php
+use Awcodes\FilamentQuickCreate\QuickCreatePlugin;
+use Filament\View\PanelsRenderHook;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        ->plugins([
+            QuickCreatePlugin::make()
+                ->renderUsingHook(PanelsRenderHook::SIDEBAR_NAV_END),
+        ])
+}
+```

--- a/src/QuickCreatePlugin.php
+++ b/src/QuickCreatePlugin.php
@@ -31,6 +31,8 @@ class QuickCreatePlugin implements Plugin
 
     protected bool | Closure | null $rounded = null;
 
+    protected string $renderUsingHook = 'panels::user-menu.before';
+
     public function boot(Panel $panel): void
     {
         Livewire::component('quick-create-menu', Components\QuickCreateMenu::class);
@@ -146,7 +148,7 @@ class QuickCreatePlugin implements Plugin
     {
         $panel
             ->renderHook(
-                name: 'panels::user-menu.before',
+                name: $this->renderUsingHook,
                 hook: fn (): string => Blade::render('@livewire(\'quick-create-menu\')')
             );
     }
@@ -191,5 +193,12 @@ class QuickCreatePlugin implements Plugin
     public function shouldBeHidden(): bool
     {
         return $this->evaluate($this->hidden) ?? false;
+    }
+
+    public function renderUsingHook(string $panelHook): string
+    {
+        $this->renderUsingHook = $panelHook;
+
+        return $this;
     }
 }

--- a/src/QuickCreatePlugin.php
+++ b/src/QuickCreatePlugin.php
@@ -195,7 +195,7 @@ class QuickCreatePlugin implements Plugin
         return $this->evaluate($this->hidden) ?? false;
     }
 
-    public function renderUsingHook(string $panelHook): string
+    public function renderUsingHook(string $panelHook): static
     {
         $this->renderUsingHook = $panelHook;
 


### PR DESCRIPTION
Adding functionality to render the plugin in a  custom render hook. This is useful when a developer customizes their theme and the plugin creates UI issues when it renders using the default hook.
Updated the documentation for the changes. 