### PR TITLE
Optionally override resource label

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,21 @@ public function panel(Panel $panel): Panel
 }
 ```
 
+### Custom resource label
+
+By default, Quick Create will create the label from the resource's model. You can override this by providing an optional `getQuickCreateLabel` in your resource class.
+
+```php
+
+namespace App\Filament\Resources;
+
+class AgentResource extends Resource {
+    public function getQuickCreateLabel() {
+        return __('Agent');
+    }
+}
+```
+
 ### Registering keybindings
 
 You can attach keyboard shortcuts to trigger the Quick Create dropdown. To configure these, pass the keyBindings() method to the configuration:

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ public function panel(Panel $panel): Panel
 
 ### Custom resource label
 
-By default, Quick Create will create the label from the resource's model. You can override this by providing an optional `getQuickCreateLabel` in your resource class.
+By default, Quick Create will create the label from the resource's model. You can override this by providing an optional `getQuickCreateLabel()` method in your resource class.
 
 ```php
 

--- a/src/QuickCreatePlugin.php
+++ b/src/QuickCreatePlugin.php
@@ -24,30 +24,30 @@ class QuickCreatePlugin implements Plugin
 
     protected bool $sort = true;
 
-    protected bool | Closure | null $shouldUseSlideOver = null;
+    protected bool|Closure|null $shouldUseSlideOver = null;
 
-    protected string | Closure $sortBy = 'label';
+    protected string|Closure $sortBy = 'label';
 
-    protected bool | Closure $hidden = false;
+    protected bool|Closure $hidden = false;
 
-    protected bool | Closure | null $rounded = null;
+    protected bool|Closure|null $rounded = null;
 
-    protected string | Closure | null $renderUsingHook = null;
+    protected string|Closure|null $renderUsingHook = null;
 
-    protected bool | Closure | null $hiddenIcons = null;
+    protected bool|Closure|null $hiddenIcons = null;
 
-    protected string | Closure | null $label = null;
+    protected string|Closure|null $label = null;
 
-    protected bool | Closure $shouldUseModal = false;
+    protected bool|Closure $shouldUseModal = false;
 
-    protected string | array | Closure | null $keyBindings = null;
+    protected string|array|Closure|null $keyBindings = null;
 
-    protected bool | Closure | null $createAnother = null;
+    protected bool|Closure|null $createAnother = null;
 
     public function boot(Panel $panel): void
     {
         Livewire::component('quick-create-menu', Components\QuickCreateMenu::class);
-        $this->getResourcesUsing(fn () => $panel->getResources());
+        $this->getResourcesUsing(fn() => $panel->getResources());
     }
 
     public function excludes(array $resources): static
@@ -64,7 +64,7 @@ class QuickCreatePlugin implements Plugin
         return $this;
     }
 
-    public function rounded(bool | Closure $condition = true): static
+    public function rounded(bool|Closure $condition = true): static
     {
         $this->rounded = $condition;
 
@@ -99,12 +99,12 @@ class QuickCreatePlugin implements Plugin
 
         $list = collect($resources)
             ->filter(function ($item) {
-                return ! in_array($item, $this->getExcludes());
+                return !in_array($item, $this->getExcludes());
             })
             ->map(function ($resourceName): ?array {
                 $resource = app($resourceName);
 
-                if (Filament::hasTenancy() && ! Filament::getTenant()) {
+                if (Filament::hasTenancy() && !Filament::getTenant()) {
                     return null;
                 }
 
@@ -113,19 +113,19 @@ class QuickCreatePlugin implements Plugin
 
                     return [
                         'resource_name' => $resourceName,
-                        'label' => Str::ucfirst($resource->getModelLabel()),
-                        'model' => $resource->getModel(),
-                        'icon' => $resource->getNavigationIcon(),
-                        'action_name' => $actionName,
-                        'action' => ! $resource->hasPage('create') || $this->shouldUseModal() ? 'mountAction(\'' . $actionName . '\')' : null,
-                        'url' => $resource->hasPage('create') && ! $this->shouldUseModal() ? $resource::getUrl('create') : null,
-                        'navigation' => $resource->getNavigationSort(),
+                        'label'         => Str::ucfirst(method_exists($resource, 'getQuickCreateLabel') ? call_user_func_array([$resource, 'getQuickCreateLabel'], []) : $resource->getModelLabel()),
+                        'model'         => $resource->getModel(),
+                        'icon'          => $resource->getNavigationIcon(),
+                        'action_name'   => $actionName,
+                        'action'        => !$resource->hasPage('create') || $this->shouldUseModal() ? 'mountAction(\'' . $actionName . '\')' : null,
+                        'url'           => $resource->hasPage('create') && !$this->shouldUseModal() ? $resource::getUrl('create') : null,
+                        'navigation'    => $resource->getNavigationSort(),
                     ];
                 }
 
                 return null;
             })
-            ->when($this->isSortable(), fn ($collection) => $collection->sortBy($this->sortBy))
+            ->when($this->isSortable(), fn($collection) => $collection->sortBy($this->sortBy))
             ->values()
             ->toArray();
 
@@ -159,7 +159,7 @@ class QuickCreatePlugin implements Plugin
         $panel
             ->renderHook(
                 name: $this->getRenderHook(),
-                hook: fn (): string => Blade::render("@livewire('quick-create-menu')")
+                hook: fn(): string => Blade::render("@livewire('quick-create-menu')")
             );
     }
 
@@ -175,16 +175,16 @@ class QuickCreatePlugin implements Plugin
         return $this;
     }
 
-    public function sort(bool | Closure $condition = true): static
+    public function sort(bool|Closure $condition = true): static
     {
         $this->sort = $condition;
 
         return $this;
     }
 
-    public function sortBy(string | Closure $sortBy = 'label'): static
+    public function sortBy(string|Closure $sortBy = 'label'): static
     {
-        if (! in_array($sortBy, ['label', 'navigation'])) {
+        if (!in_array($sortBy, ['label', 'navigation'])) {
             $sortBy = 'label';
         }
         $this->sortBy = $sortBy;
@@ -192,7 +192,7 @@ class QuickCreatePlugin implements Plugin
         return $this;
     }
 
-    public function hidden(bool | Closure $hidden = true): static
+    public function hidden(bool|Closure $hidden = true): static
     {
         $this->hidden = $hidden;
 
@@ -204,7 +204,7 @@ class QuickCreatePlugin implements Plugin
         return $this->evaluate($this->hidden) ?? false;
     }
 
-    public function renderUsingHook(string | Closure $panelHook): static
+    public function renderUsingHook(string|Closure $panelHook): static
     {
         $this->renderUsingHook = $panelHook;
 
@@ -216,7 +216,7 @@ class QuickCreatePlugin implements Plugin
         return $this->evaluate($this->renderUsingHook) ?? PanelsRenderHook::USER_MENU_BEFORE;
     }
 
-    public function hiddenIcons(bool | Closure $condition = true): static
+    public function hiddenIcons(bool|Closure $condition = true): static
     {
         $this->hiddenIcons = $condition;
 
@@ -228,7 +228,7 @@ class QuickCreatePlugin implements Plugin
         return $this->evaluate($this->hiddenIcons) ?? false;
     }
 
-    public function label(string | Closure $label): static
+    public function label(string|Closure $label): static
     {
         $this->label = $label;
 
@@ -245,14 +245,14 @@ class QuickCreatePlugin implements Plugin
         return $this->evaluate($this->shouldUseModal) ?? false;
     }
 
-    public function alwaysShowModal(bool | Closure $condition = true): static
+    public function alwaysShowModal(bool|Closure $condition = true): static
     {
         $this->shouldUseModal = $condition;
 
         return $this;
     }
 
-    public function keyBindings(string | array | Closure | null $bindings): static
+    public function keyBindings(string|array|Closure|null $bindings): static
     {
         $this->keyBindings = $bindings;
 
@@ -264,7 +264,7 @@ class QuickCreatePlugin implements Plugin
         return collect($this->evaluate($this->keyBindings))->toArray();
     }
 
-    public function createAnother(bool | Closure $condition = true): static
+    public function createAnother(bool|Closure $condition = true): static
     {
         $this->createAnother = $condition;
 


### PR DESCRIPTION
By default, Quick Create will create the label from the resource's model name. We can override this by providing an optional `getQuickCreateLabel()` method in the resource class.