### PR TITLE
feat(QuickCreateMenu): add modal customization options

### DIFF
--- a/src/Components/QuickCreateMenu.php
+++ b/src/Components/QuickCreateMenu.php
@@ -77,7 +77,7 @@ class QuickCreateMenu extends Component implements HasActions, HasForms
     public function getActions(): array
     {
         return collect($this->resources)
-            ->transform(function ($resource) {
+            ->transform(function ($resource, $index) {
                 $r = App::make($resource['resource_name']);
                 $canCreateAnother = QuickCreatePlugin::get()->canCreateAnother();
 
@@ -109,6 +109,10 @@ class QuickCreateMenu extends Component implements HasActions, HasForms
                     ->authorize($r::canCreate())
                     ->model($resource['model'])
                     ->slideOver(fn (): bool => QuickCreatePlugin::get()->shouldUseSlideOver())
+                    ->modalWidth(fn (): ?string => QuickCreatePlugin::get()->getModalWidth($index))
+                    ->modalHeading(fn () => QuickCreatePlugin::get()->getModalHeading($resource['label']))
+                    ->modalDescription(fn () => QuickCreatePlugin::get()->getModalDescription($resource['label']))
+                    ->extraModalWindowAttributes(fn () => QuickCreatePlugin::get()->getModalExtraAttributes())
                     ->form(function ($arguments, $form) use ($r) {
                         return $r->form($form->operation('create')->columns());
                     })

--- a/src/Components/QuickCreateMenu.php
+++ b/src/Components/QuickCreateMenu.php
@@ -83,7 +83,7 @@ class QuickCreateMenu extends Component implements HasActions, HasForms
 
                 if ($canCreateAnother === null) {
                     $canCreateAnother = true;
-                    
+
                     if ($r->hasPage('create')) {
                         $canCreateAnother = App::make($r->getPages()['create']->getPage())::canCreateAnother();
                     } else {

--- a/src/QuickCreatePlugin.php
+++ b/src/QuickCreatePlugin.php
@@ -26,33 +26,33 @@ class QuickCreatePlugin implements Plugin
 
     protected bool $sort = true;
 
-    protected bool|Closure|null $shouldUseSlideOver = null;
+    protected bool | Closure | null $shouldUseSlideOver = null;
 
-    protected string|Closure $sortBy = 'label';
+    protected string | Closure $sortBy = 'label';
 
-    protected bool|Closure $hidden = false;
+    protected bool | Closure $hidden = false;
 
-    protected bool|Closure|null $rounded = null;
+    protected bool | Closure | null $rounded = null;
 
-    protected string|Closure|null $renderUsingHook = null;
+    protected string | Closure | null $renderUsingHook = null;
 
-    protected bool|Closure|null $hiddenIcons = null;
+    protected bool | Closure | null $hiddenIcons = null;
 
-    protected string|Closure|null $label = null;
+    protected string | Closure | null $label = null;
 
-    protected bool|Closure $shouldUseModal = false;
+    protected bool | Closure $shouldUseModal = false;
 
-    protected string|array|Closure|null $keyBindings = null;
+    protected string | array | Closure | null $keyBindings = null;
 
-    protected bool|Closure|null $createAnother = null;
+    protected bool | Closure | null $createAnother = null;
 
-    protected string|array|Closure|null $modalWidths = null;
+    protected string | array | Closure | null $modalWidths = null;
 
-    protected string|Closure|null $modalHeading = null;
+    protected string | Closure | null $modalHeading = null;
 
-    protected string|Closure|null $modalDescription = null;
+    protected string | Closure | null $modalDescription = null;
 
-    protected array|Closure|null $modalExtraAttributes = null;
+    protected array | Closure | null $modalExtraAttributes = null;
 
     public function boot(Panel $panel): void
     {
@@ -74,7 +74,7 @@ class QuickCreatePlugin implements Plugin
         return $this;
     }
 
-    public function rounded(bool|Closure $condition = true): static
+    public function rounded(bool | Closure $condition = true): static
     {
         $this->rounded = $condition;
 
@@ -119,7 +119,7 @@ class QuickCreatePlugin implements Plugin
                 }
 
                 if ($resource->canCreate()) {
-                    $actionName = 'create_'.Str::of($resource->getModel())->replace('\\', '')->snake();
+                    $actionName = 'create_' . Str::of($resource->getModel())->replace('\\', '')->snake();
 
                     return [
                         'resource_name' => $resourceName,
@@ -127,7 +127,7 @@ class QuickCreatePlugin implements Plugin
                         'model' => $resource->getModel(),
                         'icon' => $resource->getNavigationIcon(),
                         'action_name' => $actionName,
-                        'action' => ! $resource->hasPage('create') || $this->shouldUseModal() ? 'mountAction(\''.$actionName.'\')' : null,
+                        'action' => ! $resource->hasPage('create') || $this->shouldUseModal() ? 'mountAction(\'' . $actionName . '\')' : null,
                         'url' => $resource->hasPage('create') && ! $this->shouldUseModal() ? $resource::getUrl('create') : null,
                         'navigation' => $resource->getNavigationSort(),
                     ];
@@ -185,14 +185,14 @@ class QuickCreatePlugin implements Plugin
         return $this;
     }
 
-    public function sort(bool|Closure $condition = true): static
+    public function sort(bool | Closure $condition = true): static
     {
         $this->sort = $condition;
 
         return $this;
     }
 
-    public function sortBy(string|Closure $sortBy = 'label'): static
+    public function sortBy(string | Closure $sortBy = 'label'): static
     {
         if (! in_array($sortBy, ['label', 'navigation'])) {
             $sortBy = 'label';
@@ -202,7 +202,7 @@ class QuickCreatePlugin implements Plugin
         return $this;
     }
 
-    public function hidden(bool|Closure $hidden = true): static
+    public function hidden(bool | Closure $hidden = true): static
     {
         $this->hidden = $hidden;
 
@@ -214,7 +214,7 @@ class QuickCreatePlugin implements Plugin
         return $this->evaluate($this->hidden) ?? false;
     }
 
-    public function renderUsingHook(string|Closure $panelHook): static
+    public function renderUsingHook(string | Closure $panelHook): static
     {
         $this->renderUsingHook = $panelHook;
 
@@ -226,7 +226,7 @@ class QuickCreatePlugin implements Plugin
         return $this->evaluate($this->renderUsingHook) ?? PanelsRenderHook::USER_MENU_BEFORE;
     }
 
-    public function hiddenIcons(bool|Closure $condition = true): static
+    public function hiddenIcons(bool | Closure $condition = true): static
     {
         $this->hiddenIcons = $condition;
 
@@ -238,7 +238,7 @@ class QuickCreatePlugin implements Plugin
         return $this->evaluate($this->hiddenIcons) ?? false;
     }
 
-    public function label(string|Closure $label): static
+    public function label(string | Closure $label): static
     {
         $this->label = $label;
 
@@ -255,14 +255,14 @@ class QuickCreatePlugin implements Plugin
         return $this->evaluate($this->shouldUseModal) ?? false;
     }
 
-    public function alwaysShowModal(bool|Closure $condition = true): static
+    public function alwaysShowModal(bool | Closure $condition = true): static
     {
         $this->shouldUseModal = $condition;
 
         return $this;
     }
 
-    public function keyBindings(string|array|Closure|null $bindings): static
+    public function keyBindings(string | array | Closure | null $bindings): static
     {
         $this->keyBindings = $bindings;
 
@@ -274,7 +274,7 @@ class QuickCreatePlugin implements Plugin
         return collect($this->evaluate($this->keyBindings))->toArray();
     }
 
-    public function createAnother(bool|Closure $condition = true): static
+    public function createAnother(bool | Closure $condition = true): static
     {
         $this->createAnother = $condition;
 
@@ -286,7 +286,7 @@ class QuickCreatePlugin implements Plugin
         return $this->evaluate($this->createAnother);
     }
 
-    public function modalWidths(string|array|Closure $widths): static
+    public function modalWidths(string | array | Closure $widths): static
     {
         $this->modalWidths = $widths;
 
@@ -308,7 +308,7 @@ class QuickCreatePlugin implements Plugin
         return null;
     }
 
-    public function modalHeading(string|Closure $heading): static
+    public function modalHeading(string | Closure $heading): static
     {
         $this->modalHeading = $heading;
 
@@ -322,7 +322,7 @@ class QuickCreatePlugin implements Plugin
         return $heading ? str_replace(':label', $resourceLabel, $heading) : null;
     }
 
-    public function modalDescription(string|Closure $description): static
+    public function modalDescription(string | Closure $description): static
     {
         $this->modalDescription = $description;
 
@@ -336,7 +336,7 @@ class QuickCreatePlugin implements Plugin
         return $description ? str_replace(':label', $resourceLabel, $description) : null;
     }
 
-    public function modalExtraAttributes(array|Closure $attributes): static
+    public function modalExtraAttributes(array | Closure $attributes): static
     {
         $this->modalExtraAttributes = $attributes;
 

--- a/src/QuickCreatePlugin.php
+++ b/src/QuickCreatePlugin.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Awcodes\FilamentQuickCreate;
 
 use Closure;
@@ -24,25 +26,33 @@ class QuickCreatePlugin implements Plugin
 
     protected bool $sort = true;
 
-    protected bool | Closure | null $shouldUseSlideOver = null;
+    protected bool|Closure|null $shouldUseSlideOver = null;
 
-    protected string | Closure $sortBy = 'label';
+    protected string|Closure $sortBy = 'label';
 
-    protected bool | Closure $hidden = false;
+    protected bool|Closure $hidden = false;
 
-    protected bool | Closure | null $rounded = null;
+    protected bool|Closure|null $rounded = null;
 
-    protected string | Closure | null $renderUsingHook = null;
+    protected string|Closure|null $renderUsingHook = null;
 
-    protected bool | Closure | null $hiddenIcons = null;
+    protected bool|Closure|null $hiddenIcons = null;
 
-    protected string | Closure | null $label = null;
+    protected string|Closure|null $label = null;
 
-    protected bool | Closure $shouldUseModal = false;
+    protected bool|Closure $shouldUseModal = false;
 
-    protected string | array | Closure | null $keyBindings = null;
+    protected string|array|Closure|null $keyBindings = null;
 
-    protected bool | Closure | null $createAnother = null;
+    protected bool|Closure|null $createAnother = null;
+
+    protected string|array|Closure|null $modalWidths = null;
+
+    protected string|Closure|null $modalHeading = null;
+
+    protected string|Closure|null $modalDescription = null;
+
+    protected array|Closure|null $modalExtraAttributes = null;
 
     public function boot(Panel $panel): void
     {
@@ -64,7 +74,7 @@ class QuickCreatePlugin implements Plugin
         return $this;
     }
 
-    public function rounded(bool | Closure $condition = true): static
+    public function rounded(bool|Closure $condition = true): static
     {
         $this->rounded = $condition;
 
@@ -109,7 +119,7 @@ class QuickCreatePlugin implements Plugin
                 }
 
                 if ($resource->canCreate()) {
-                    $actionName = 'create_' . Str::of($resource->getModel())->replace('\\', '')->snake();
+                    $actionName = 'create_'.Str::of($resource->getModel())->replace('\\', '')->snake();
 
                     return [
                         'resource_name' => $resourceName,
@@ -117,7 +127,7 @@ class QuickCreatePlugin implements Plugin
                         'model' => $resource->getModel(),
                         'icon' => $resource->getNavigationIcon(),
                         'action_name' => $actionName,
-                        'action' => ! $resource->hasPage('create') || $this->shouldUseModal() ? 'mountAction(\'' . $actionName . '\')' : null,
+                        'action' => ! $resource->hasPage('create') || $this->shouldUseModal() ? 'mountAction(\''.$actionName.'\')' : null,
                         'url' => $resource->hasPage('create') && ! $this->shouldUseModal() ? $resource::getUrl('create') : null,
                         'navigation' => $resource->getNavigationSort(),
                     ];
@@ -175,14 +185,14 @@ class QuickCreatePlugin implements Plugin
         return $this;
     }
 
-    public function sort(bool | Closure $condition = true): static
+    public function sort(bool|Closure $condition = true): static
     {
         $this->sort = $condition;
 
         return $this;
     }
 
-    public function sortBy(string | Closure $sortBy = 'label'): static
+    public function sortBy(string|Closure $sortBy = 'label'): static
     {
         if (! in_array($sortBy, ['label', 'navigation'])) {
             $sortBy = 'label';
@@ -192,7 +202,7 @@ class QuickCreatePlugin implements Plugin
         return $this;
     }
 
-    public function hidden(bool | Closure $hidden = true): static
+    public function hidden(bool|Closure $hidden = true): static
     {
         $this->hidden = $hidden;
 
@@ -204,7 +214,7 @@ class QuickCreatePlugin implements Plugin
         return $this->evaluate($this->hidden) ?? false;
     }
 
-    public function renderUsingHook(string | Closure $panelHook): static
+    public function renderUsingHook(string|Closure $panelHook): static
     {
         $this->renderUsingHook = $panelHook;
 
@@ -216,7 +226,7 @@ class QuickCreatePlugin implements Plugin
         return $this->evaluate($this->renderUsingHook) ?? PanelsRenderHook::USER_MENU_BEFORE;
     }
 
-    public function hiddenIcons(bool | Closure $condition = true): static
+    public function hiddenIcons(bool|Closure $condition = true): static
     {
         $this->hiddenIcons = $condition;
 
@@ -228,7 +238,7 @@ class QuickCreatePlugin implements Plugin
         return $this->evaluate($this->hiddenIcons) ?? false;
     }
 
-    public function label(string | Closure $label): static
+    public function label(string|Closure $label): static
     {
         $this->label = $label;
 
@@ -245,14 +255,14 @@ class QuickCreatePlugin implements Plugin
         return $this->evaluate($this->shouldUseModal) ?? false;
     }
 
-    public function alwaysShowModal(bool | Closure $condition = true): static
+    public function alwaysShowModal(bool|Closure $condition = true): static
     {
         $this->shouldUseModal = $condition;
 
         return $this;
     }
 
-    public function keyBindings(string | array | Closure | null $bindings): static
+    public function keyBindings(string|array|Closure|null $bindings): static
     {
         $this->keyBindings = $bindings;
 
@@ -264,7 +274,7 @@ class QuickCreatePlugin implements Plugin
         return collect($this->evaluate($this->keyBindings))->toArray();
     }
 
-    public function createAnother(bool | Closure $condition = true): static
+    public function createAnother(bool|Closure $condition = true): static
     {
         $this->createAnother = $condition;
 
@@ -274,5 +284,67 @@ class QuickCreatePlugin implements Plugin
     public function canCreateAnother(): ?bool
     {
         return $this->evaluate($this->createAnother);
+    }
+
+    public function modalWidths(string|array|Closure $widths): static
+    {
+        $this->modalWidths = $widths;
+
+        return $this;
+    }
+
+    public function getModalWidth(int $index = 0): ?string
+    {
+        $widths = $this->evaluate($this->modalWidths);
+
+        if (is_string($widths)) {
+            return $widths;
+        }
+
+        if (is_array($widths)) {
+            return $widths[$index] ?? array_values($widths)[0] ?? null;
+        }
+
+        return null;
+    }
+
+    public function modalHeading(string|Closure $heading): static
+    {
+        $this->modalHeading = $heading;
+
+        return $this;
+    }
+
+    public function getModalHeading(string $resourceLabel): ?string
+    {
+        $heading = $this->evaluate($this->modalHeading);
+
+        return $heading ? str_replace(':label', $resourceLabel, $heading) : null;
+    }
+
+    public function modalDescription(string|Closure $description): static
+    {
+        $this->modalDescription = $description;
+
+        return $this;
+    }
+
+    public function getModalDescription(string $resourceLabel): ?string
+    {
+        $description = $this->evaluate($this->modalDescription);
+
+        return $description ? str_replace(':label', $resourceLabel, $description) : null;
+    }
+
+    public function modalExtraAttributes(array|Closure $attributes): static
+    {
+        $this->modalExtraAttributes = $attributes;
+
+        return $this;
+    }
+
+    public function getModalExtraAttributes(): ?array
+    {
+        return $this->evaluate($this->modalExtraAttributes);
     }
 }


### PR DESCRIPTION
Add support for customizing modal width, heading, description, and extra attributes in QuickCreateMenu. This allows for more flexible and user-friendly modal configurations based on resource labels and indices. 