### PR TITLE
Move Livewire component registration from boot() to register()

### DIFF
--- a/src/QuickCreatePlugin.php
+++ b/src/QuickCreatePlugin.php
@@ -68,7 +68,6 @@ class QuickCreatePlugin implements Plugin
 
     public function boot(Panel $panel): void
     {
-        Livewire::component('quick-create-menu', Components\QuickCreateMenu::class);
         $this->getResourcesUsing(fn (): array => $panel->getResources());
     }
 
@@ -175,6 +174,8 @@ class QuickCreatePlugin implements Plugin
 
     public function register(Panel $panel): void
     {
+        Livewire::component('quick-create-menu', Components\QuickCreateMenu::class);
+
         $panel
             ->renderHook(
                 name: $this->getRenderHook(),


### PR DESCRIPTION
## Problem

The `Livewire::component('quick-create-menu', ...)` call currently lives in the plugin's `boot()` method. In Livewire v4.2.0, internal timing changes mean this registration happens too late, causing:

```
Unable to find component: [quick-create-menu]
```

## Root Cause

Filament's plugin lifecycle has two phases:

- **`register()`** runs during service provider registration (i.e., `ServiceProvider::register()`). This is the standard phase for binding components into the container and registering Livewire components.
- **`boot()`** runs lazily — it's triggered by Filament's middleware during HTTP request handling, after the framework has already booted.

Livewire v4.2.0 tightened its internal component resolution timing, and by the time `boot()` fires through Filament's middleware, it's too late for Livewire to recognize the component.

## Fix

Move the `Livewire::component()` call from `boot()` to `register()`, placing it before the existing `renderHook()` registration. This ensures the component is available when Livewire needs it.

This matches the pattern used in [awcodes/recently](https://github.com/awcodes/recently), which correctly registers its Livewire component in `register()`.

## Changes

- `src/QuickCreatePlugin.php`: Moved `Livewire::component('quick-create-menu', Components\QuickCreateMenu::class)` from `boot()` to `register()`